### PR TITLE
Link back to Markdown source file and position

### DIFF
--- a/src/Daemon.hs
+++ b/src/Daemon.hs
@@ -198,14 +198,15 @@ tangleTargets = do
 loadSourceFile :: FilePath -> TangleM (Either TangleError Document)
 loadSourceFile f = do
     source  <- liftIO $ T.IO.readFile f
-    parseMarkdown f source
+    shortPath <- liftIO $ makeRelativeToCurrentDirectory f
+    parseMarkdown shortPath source
 
 addSourceFile :: FilePath -> TangleM IOAction
 addSourceFile f = do
     shortPath <- liftIO $ makeRelativeToCurrentDirectory f
     source  <- liftIO $ T.IO.readFile f
     refs    <- use referenceMap
-    doc'    <- parseMarkdown' refs f source
+    doc'    <- parseMarkdown' refs shortPath source
     case doc' of
         Left err -> return $ msg Error $
             "Error loading '" ++ shortPath ++ "': " ++ show err

--- a/src/Document.hs
+++ b/src/Document.hs
@@ -17,6 +17,7 @@ module Document
 import qualified Data.Text as T
 import qualified Data.Map.Strict as M
 import Data.Maybe
+import Text.Parsec (SourcePos)
 
 unlines' :: [T.Text] -> T.Text
 unlines' = T.intercalate (T.pack "\n")
@@ -45,6 +46,7 @@ data CodeBlock = CodeBlock
     { codeLanguage   :: String
     , codeProperties :: [CodeProperty]
     , codeSource     :: T.Text
+    , sourcePos      :: SourcePos
     } deriving (Show, Eq)
 
 {-| Each 'ReferenceID' connects to a 'CodeBlock'
@@ -79,7 +81,7 @@ contentToText ref (RawText x) = Just x
 contentToText ref (Reference r) 
     | code == T.pack "" = Nothing
     | otherwise         = Just code
-    where CodeBlock _ _ code = ref M.! r
+    where CodeBlock _ _ code _ = ref M.! r
 
 stitchText :: Document -> T.Text
 stitchText (Document refs c) = T.unlines $ mapMaybe (contentToText refs) c

--- a/src/Markdown.hs
+++ b/src/Markdown.hs
@@ -22,7 +22,7 @@ import qualified Text.Parsec as Parsec
 import Text.Parsec.Text
 import Text.Parsec (
       manyTill, anyChar, try, string, many1, many, noneOf, spaces, endBy, (<|>)
-    , eof, endOfLine, lookAhead, newline, option)
+    , eof, endOfLine, lookAhead, newline, option, getPosition)
 
 import Config
 import Model (TangleError, toTangleError)
@@ -138,11 +138,12 @@ fromCodeBlock code = do
 parseCodeBlock' :: (MonadReader Config m, MonadState s m, RandomGen s) => DocumentParser m [Content]
 parseCodeBlock' = do
     (begin, props) <- token parseDelim
+    pos            <- getPosition
     content        <- manyTill (token Just) (try $ lookAhead $ token parseDelim)
     (end, _)       <- token parseDelim
     language       <- getLanguage props
     let langName = maybe "<unknown-language>" languageName language
-    ref            <- fromCodeBlock $ CodeBlock langName props (unlines' content)
+    ref            <- fromCodeBlock $ CodeBlock langName props (unlines' content) pos
     return [RawText begin, ref, RawText end]
 
 parseNormalBlock' :: Monad m => DocumentParser m [Content]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -40,7 +40,7 @@ markdownSpecs lib = do
             it "has a file reference to 'hello.cc'" $
                 refMap `shouldSatisfy` (\m -> FileReferenceId "hello.cc" `Map.member` m)
 
-            let CodeBlock lang _ code = refMap Map.! FileReferenceId "hello.cc"
+            let CodeBlock lang _ code pos = refMap Map.! FileReferenceId "hello.cc"
             it "has a codeblock in c++" $
                 lang `shouldBe` "C++"
 


### PR DESCRIPTION
Appends a `project://MarkdownSource.md#linenumber` link to every tangled CodeBlock.
This scheme is clickable in Visual Studio Code (after installing [this extension](https://github.com/KyleDavidE/vscode-project-links)) and makes one jump directly inside the code block!

I'm not sure if other editors support the same URL scheme.

---

Given `Test.md`:

~~~
# Test entangled

## Cpp file

Guess what?

```c++ {file=test.cpp}
This is not C++ at all!
```
~~~

Output:

```c++
// ------ language="C++" file="test.cpp" project://Test.md#8
This is not C++ at all!
// ------ end
```

---
PS:
This is my first time hacking on Haskell code, so it's likely not idiomatic, or plain ugly.