### PR TITLE
Fix for disappearing code, when using <<reference>> in multiple markdown files

### DIFF
--- a/src/Daemon.hs
+++ b/src/Daemon.hs
@@ -396,6 +396,7 @@ startSession fs = do
     ts <- timeStamp
     run $ msgGroup (ts P.<+> P.pretty "Initializing")
         $ w <> x <> y
+    wait -- for intial tangle to complete before watching target files
     setWatch >>= run
     eventList' <- use $ eventChannel . to getChanContents
     eventList  <- liftIO eventList'

--- a/src/Tangle.hs
+++ b/src/Tangle.hs
@@ -108,8 +108,8 @@ tangleNaked (Document refs _) = Map.fromList $ zip fileNames sources
 
 {- Annotated tangle -}
 topAnnotation :: ReferenceId -> String -> String -> String -> SourcePos -> String
-topAnnotation (NameReferenceId n i) comment close lang pos =
-    comment ++ " begin <<" ++ n ++ ">>[" ++ show i ++ "] project://" ++ sourceName pos ++ "#" ++ (show $ sourceLine pos) ++ close
+topAnnotation (NameReferenceId n sourceId i) comment close lang pos =
+    comment ++ " begin <<" ++ n ++ ">>[" ++ sourceId ++ ":" ++ show i ++ "] project://" ++ sourceName pos ++ "#" ++ (show $ sourceLine pos) ++ close
 topAnnotation (FileReferenceId n) comment close lang pos =
     comment ++ " language=\"" ++ lang ++ "\" file=\"" ++ n ++ "\" project://" ++ sourceName pos ++ "#" ++ (show $ sourceLine pos) ++ close
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -29,7 +29,7 @@ import Document
 parseMarkdown'' :: T.Text -> IO (Either TangleError Document)
 parseMarkdown'' t = do
     randomGen <- getStdGen
-    runReaderT (fst <$> runStateT (parseMarkdown "" t) randomGen) defaultConfig
+    runReaderT (fst <$> runStateT (parseMarkdown "hello.cc" t) randomGen) defaultConfig
 
 markdownSpecs :: Map.Map FilePath (T.Text, Document) -> Spec
 markdownSpecs lib = do
@@ -93,7 +93,7 @@ markdownSpecs lib = do
             let rm  = fromRight' rm'
             it "recovers the identical code block" $ do
                 let ref1 = FileReferenceId "hello.cc"
-                    ref2 = NameReferenceId "main-body" 0
+                    ref2 = NameReferenceId "main-body" "hello" 0
                 codeSource (rm Map.! ref1) `shouldBe` codeSource (rmo Map.! ref1)
                 codeSource (rm Map.! ref2) `shouldBe` codeSource (rmo Map.! ref2)
             


### PR DESCRIPTION
When using the same macro across multiple Markdown
 source files, the initial tangle is correct, and
 appends to the code block in the order given as
 program arguments, but when subsequently changing
 one of the markdown files, the other file’s code
 blocks are deleted as the count restarts from 0.

This patch uses each file basename to uniquely
 identify where the name reference was used, which
 fixes the above described issue.
