### PR TITLE
Implement command line option to disable line directives.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,13 +7,15 @@ import Config
 import Daemon
 
 data Args = Args
-    { versionFlag :: Bool
-    , inputFiles  :: [String]
+    { versionFlag      :: Bool
+    , noLineDirectives :: Bool
+    , inputFiles       :: [String]
     } deriving (Show)
 
 parseArgs :: Parser Args
 parseArgs = Args
-    <$> switch (long "version" <> short 'v' <> help "Show version information.")
+    <$> switch (long "version"  <> short 'v' <> help "Show version information.")
+    <*> switch (long "no-lines" <>              help "Do not use line directives to point to source file.")
     <*> many (argument str (metavar "FILES..."))
 
 main :: IO ()
@@ -28,4 +30,5 @@ run :: Args -> IO ()
 run args
     | versionFlag args       = putStrLn "enTangleD 0.2.0"
     | null (inputFiles args) = putStrLn "Need input files"
-    | otherwise              = runSession defaultConfig (inputFiles args)
+    | noLineDirectives args  = runSession (disableLineDirectives defaultConfig) (inputFiles args)
+    | otherwise              = runSession                        defaultConfig  (inputFiles args)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,6 +5,7 @@ module Config
     , defaultConfig
     , languageFromName
     , languageFromAbbrev
+    , disableLineDirectives
     ) where
 
 import Languages
@@ -73,3 +74,8 @@ noLineDirective = LineDirective (\_ _ -> "") (\_ -> False)
 
 defaultConfig = Config defaultLanguages
 
+disableLineDirectives :: Config -> Config
+disableLineDirectives conf =
+    conf { configLanguages = disableLineDirective <$> configLanguages conf }
+  where
+    disableLineDirective lang = lang { languageLineDirective = noLineDirective }


### PR DESCRIPTION
This allows to use `--no-lines` CLI option in case we want to disable line directives,
and fix the issues while editing illiterate code.