### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Features:
 
 `Entangled` is written in [Haskell](https://www.haskell.org/), and uses the `cabal` build system. You can build an executable by running
 
+    # (requires cabal >= 3.x)
     cabal build
 
 Install the executable in your `~/.local/bin`


### PR DESCRIPTION
added comment with cabal required version based on limited testing. As in ``1.24.0.2`` didnt work but ``3.2.0.0`` did.