### PR TITLE
make recognized syntax configurable

### DIFF
--- a/data/config-schema.dhall
+++ b/data/config-schema.dhall
@@ -62,20 +62,36 @@ let lineDirectives =
 
 let Annotate = < Naked | Standard | Project >
 
+let Syntax : Type =
+    { matchCodeStart       : Text
+    , extractLanguage      : Text
+    , extractFileName      : Text
+    , extractReferenceName : Text
+    , matchCodeEnd         : Text }
+
+let defaultSyntax : Syntax =
+    { matchCodeStart       = "```[ ]+{[^{}]*}"
+    , matchCodeEnd         = "```"
+    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+
 let Config =
     { Type =
         { version   : Text
         , languages : List Language
         , watchList : List Text
         , database  : Optional Text
+        , syntax    : Syntax
         , annotate  : Annotate
         , lineDirectives : List LineDirective
         , useLineDirectives : Bool }
     , default =
-        { version   = "1.0.0"
+        { version   = "1.2.0"
         , languages = languages
         , watchList = [] : List Text
         , database  = None Text
+        , syntax    = defaultSyntax
         , annotate  = Annotate.Standard
         , lineDirectives = lineDirectives
         , useLineDirectives = False }

--- a/data/config-schema.dhall
+++ b/data/config-schema.dhall
@@ -70,11 +70,11 @@ let Syntax : Type =
     , matchCodeEnd         : Text }
 
 let defaultSyntax : Syntax =
-    { matchCodeStart       = "```[ ]+{[^{}]*}"
-    , matchCodeEnd         = "```"
-    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
-    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
-    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+    { matchCodeStart       = "^[ ]*```[ ]*{[^{}]*}"
+    , matchCodeEnd         = "^[ ]*```"
+    , extractLanguage      = "```[ ]*{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]*{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]*{[^{}]*file=([^{} \t]*)[^{}]*}" }
 
 let Config =
     { Type =

--- a/data/example-config.dhall
+++ b/data/example-config.dhall
@@ -74,11 +74,11 @@ let languages = entangled.languages #
    case you may whish to change these settings.
  -}
 let syntax : Syntax =
-    { matchCodeStart       = "```[ ]+{[^{}]*}"
+    { matchCodeStart       = "```[ ]*{[^{}]*}"
     , matchCodeEnd         = "```"
-    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
-    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
-    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+    , extractLanguage      = "```[ ]*{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]*{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]*{[^{}]*file=([^{} \t]*)[^{}]*}" }
 
 {- Database
    --------

--- a/data/example-config.dhall
+++ b/data/example-config.dhall
@@ -25,8 +25,8 @@ you're
 
        dhall hash <<< <location to schema>
   -}
-let entangled = https://raw.githubusercontent.com/entangled/entangled/v1.0.1/data/config-schema.dhall
-                sha256:9fd18824499379eee53b974ca7570b3bc064fda546348d9b31841afab3b053a7
+let entangled = https://raw.githubusercontent.com/entangled/entangled/v1.2.0/data/config-schema.dhall
+i               sha256:dbf04dd6e3f7ceedb2bdafdf5b884f8d1994cbf8a760936588a76a3925b10a7e
 
 {- Languages
    ---------
@@ -63,6 +63,23 @@ let languages = entangled.languages #
     , { name = "Intercal", identifiers = ["intercal"], comment = intercalComment }
     ]
 
+{- Syntax
+   ------
+
+   (new in v1.2.0) You can configure on which syntax Entangled triggers.
+   Entangled works entirely on single line matches. From a single line it
+   needs to extract a language, reference name and/or a file name.
+   The following is the default syntax which works well with Pandoc. However,
+   there are other renderers that do not work well with that syntax. In that
+   case you may whish to change these settings.
+ -}
+let syntax : Syntax =
+    { matchCodeStart       = "```[ ]+{[^{}]*}"
+    , matchCodeEnd         = "```"
+    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+
 {- Database
    --------
   
@@ -85,7 +102,8 @@ let watchList = [ "lit/*.md" ]
 
 in { entangled = entangled.Config :: { database = database
                                      , watchList = watchList
-                                     , languages = languages }
+                                     , languages = languages
+                                     , syntax = syntax }
 
 {- Extra options
    -------------

--- a/data/minimal-config.dhall
+++ b/data/minimal-config.dhall
@@ -1,5 +1,5 @@
-let entangled = https://raw.githubusercontent.com/entangled/entangled/v1.0.1/data/config-schema.dhall
-                sha256:9fd18824499379eee53b974ca7570b3bc064fda546348d9b31841afab3b053a7
+let entangled = https://raw.githubusercontent.com/entangled/entangled/v1.2.0/data/config-schema.dhall
+i               sha256:dbf04dd6e3f7ceedb2bdafdf5b884f8d1994cbf8a760936588a76a3925b10a7e
 
 in { entangled = entangled.Config :: { database = Some ".entangled/db.sqlite"
                                      , watchList = [] : List Text

--- a/entangled.cabal
+++ b/entangled.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:           entangled
-version:        1.1.0
+version:        1.2.0
 synopsis:       bi-directional tangle daemon for literate programming
 description:    Please see the README on GitHub at <https://github.com/entangled/entangled/#readme>
 category:       Development

--- a/entangled.cabal
+++ b/entangled.cabal
@@ -43,7 +43,7 @@ common deps
     , mtl >=2.2 && <3
     , prettyprinter >=1.2 && <2
     , prettyprinter-ansi-terminal >=1.1 && <2
-    , random >=1.0 && <2
+    , regex-tdfa >=1.3 && <2
     , rio >=0.1.15 && <0.2
     , sqlite-simple >=0.4.16 && <0.5
     , terminal-size >=0.3 && <1

--- a/lit/04-configuration.md
+++ b/lit/04-configuration.md
@@ -20,11 +20,11 @@ let Syntax : Type =
     , matchCodeEnd         : Text }
 
 let defaultSyntax : Syntax =
-    { matchCodeStart       = "```[ ]+{[^{}]*}"
-    , matchCodeEnd         = "```"
-    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
-    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
-    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+    { matchCodeStart       = "^[ ]*```[ ]*{[^{}]*}"
+    , matchCodeEnd         = "^[ ]*```"
+    , extractLanguage      = "```[ ]*{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]*{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]*{[^{}]*file=([^{} \t]*)[^{}]*}" }
 
 let Config =
     { Type =

--- a/lit/04-configuration.md
+++ b/lit/04-configuration.md
@@ -12,20 +12,36 @@ let LineDirective : Type = { name : Text, format: Text }
 
 let Annotate = < Naked | Standard | Project >
 
+let Syntax : Type =
+    { matchCodeStart       : Text
+    , extractLanguage      : Text
+    , extractFileName      : Text
+    , extractReferenceName : Text
+    , matchCodeEnd         : Text }
+
+let defaultSyntax : Syntax =
+    { matchCodeStart       = "```[ ]+{[^{}]*}"
+    , matchCodeEnd         = "```"
+    , extractLanguage      = "```[ ]+{\\.([^{} \t]+)[^{}]*}"
+    , extractReferenceName = "```[ ]+{[^{}]*#([^{} \t]*)[^{}]*}"
+    , extractFileName      = "```[ ]+{[^{}]*file=([^{} \t]*)[^{}]*}" }
+
 let Config =
     { Type =
         { version   : Text
         , languages : List Language
         , watchList : List Text
         , database  : Optional Text
+        , syntax    : Syntax
         , annotate  : Annotate
         , lineDirectives : List LineDirective
         , useLineDirectives : Bool }
     , default =
-        { version   = "1.0.0"
+        { version   = "1.2.0"
         , languages = languages
         , watchList = [] : List Text
         , database  = None Text
+        , syntax    = defaultSyntax
         , annotate  = Annotate.Standard
         , lineDirectives = lineDirectives
         , useLineDirectives = False }
@@ -159,11 +175,28 @@ annotateDecoder = union
         <> ( AnnotateStandard       <$ constructor "Standard" unit )
         <> ( AnnotateProject        <$ constructor "Project" unit ) )
 
+data ConfigSyntax = ConfigSyntax
+    { matchCodeStart       :: Text
+    , matchCodeEnd         :: Text
+    , extractLanguage      :: Text
+    , extractReferenceName :: Text
+    , extractFileName      :: Text
+    } deriving (Show)
+
+configSyntaxDecoder :: Decoder ConfigSyntax
+configSyntaxDecoder = record
+    ( ConfigSyntax <$> field "matchCodeStart" auto
+                   <*> field "matchCodeEnd" auto
+                   <*> field "extractLanguage" auto
+                   <*> field "extractReferenceName" auto
+                   <*> field "extractFileName" auto )
+
 data Config = Config
     { configVersion   :: Text
     , configLanguages :: Set ConfigLanguage
     , configWatchList :: [Text]
     , configDatabase  :: Maybe Text
+    , configSyntax    :: ConfigSyntax
     , configAnnotate  :: AnnotateMethod
     , configLineDirectives :: Map Text Format.Spec
     , configUseLineDirectives :: Bool
@@ -175,6 +208,7 @@ configDecoder = record
              <*> field "languages" (setFromDistinctList configLanguage)
              <*> field "watchList" auto
              <*> field "database" auto
+             <*> field "syntax" configSyntaxDecoder
              <*> field "annotate" annotateDecoder
              <*> field "lineDirectives" lineDirectivesDecoder
              <*> field "useLineDirectives" auto

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -67,11 +67,28 @@ annotateDecoder = union
         <> ( AnnotateStandard       <$ constructor "Standard" unit )
         <> ( AnnotateProject        <$ constructor "Project" unit ) )
 
+data ConfigSyntax = ConfigSyntax
+    { matchCodeStart       :: Text
+    , matchCodeEnd         :: Text
+    , extractLanguage      :: Text
+    , extractReferenceName :: Text
+    , extractFileName      :: Text
+    } deriving (Show)
+
+configSyntaxDecoder :: Decoder ConfigSyntax
+configSyntaxDecoder = record
+    ( ConfigSyntax <$> field "matchCodeStart" auto
+                   <*> field "matchCodeEnd" auto
+                   <*> field "extractLanguage" auto
+                   <*> field "extractReferenceName" auto
+                   <*> field "extractFileName" auto )
+
 data Config = Config
     { configVersion   :: Text
     , configLanguages :: Set ConfigLanguage
     , configWatchList :: [Text]
     , configDatabase  :: Maybe Text
+    , configSyntax    :: ConfigSyntax
     , configAnnotate  :: AnnotateMethod
     , configLineDirectives :: Map Text Format.Spec
     , configUseLineDirectives :: Bool
@@ -83,6 +100,7 @@ configDecoder = record
              <*> field "languages" (setFromDistinctList configLanguage)
              <*> field "watchList" auto
              <*> field "database" auto
+             <*> field "syntax" configSyntaxDecoder
              <*> field "annotate" annotateDecoder
              <*> field "lineDirectives" lineDirectivesDecoder
              <*> field "useLineDirectives" auto


### PR DESCRIPTION
Currently the recognized syntax is hard coded. This adds configurability through regexes supplied in `entangled.dhall`.