### PR TITLE
Fix issue where daemon misses some Git events.

### DIFF
--- a/lit/10-daemon.md
+++ b/lit/10-daemon.md
@@ -282,7 +282,7 @@ runSession inputFiles = do
     logDebug $ display $ tshow cfg
     conn <- view connection
     logFunc <- view logFuncL
-    fsnotify <- liftIO FSNotify.startManager
+    fsnotify <- liftIO $ FSNotify.startManagerConf (FSNotify.defaultConfig { FSNotify.confDebounce = FSNotify.NoDebounce })
     channel <- newChan
     daemonState' <- newMVar Idle
     watches' <- newEmptyMVar

--- a/lit/10-daemon.md
+++ b/lit/10-daemon.md
@@ -163,7 +163,7 @@ setWatch = do
 
     state <- asks daemonState
     stopActions <- liftIO $ mapM
-        (\dir -> FSNotify.watchDir fsnotify dir (const True)
+        (\dir -> FSNotify.watchTree fsnotify dir (const True)
                                    (passEvent state channel srcs tgts))
         abs_dirs
     watchesMVar <- asks watches

--- a/src/Daemon.hs
+++ b/src/Daemon.hs
@@ -114,7 +114,7 @@ setWatch = do
 
     state <- asks daemonState
     stopActions <- liftIO $ mapM
-        (\dir -> FSNotify.watchDir fsnotify dir (const True)
+        (\dir -> FSNotify.watchTree fsnotify dir (const True)
                                    (passEvent state channel srcs tgts))
         abs_dirs
     watchesMVar <- asks watches

--- a/src/Daemon.hs
+++ b/src/Daemon.hs
@@ -215,7 +215,7 @@ runSession inputFiles = do
     logDebug $ display $ tshow cfg
     conn <- view connection
     logFunc <- view logFuncL
-    fsnotify <- liftIO FSNotify.startManager
+    fsnotify <- liftIO $ FSNotify.startManagerConf (FSNotify.defaultConfig { FSNotify.confDebounce = FSNotify.NoDebounce })
     channel <- newChan
     daemonState' <- newMVar Idle
     watches' <- newEmptyMVar


### PR DESCRIPTION
Replaces `watchDir` to `watchTree` which works around the bug in `fsnotify` implementation causing #69 .